### PR TITLE
Show future posts and add new blog post about AI agent quotas

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
 theme: minima
 title: auditandprofit
 description: $$$
+future: true

--- a/_posts/2026-01-05-ai-agent-quotas.md
+++ b/_posts/2026-01-05-ai-agent-quotas.md
@@ -1,0 +1,7 @@
+---
+layout: post
+title: "running the agent on programs"
+date: 2026-01-05
+---
+
+so basically im just gonna run this ai agent on all programs to scrape it all up but only on a couple quotas since the real sauce is in depth on whitebox asssets that pay hundredds of thousands


### PR DESCRIPTION
### Motivation
- The new post was not appearing because Jekyll hides future-dated posts by default. 
- Enable rendering of future posts so recent/future-dated entries are visible on the site. 
- Create the requested blog entry about running the AI agent on programs.

### Description
- Add `future: true` to `_config.yml` to allow Jekyll to publish future-dated posts. 
- Add new post file `_posts/2026-01-05-ai-agent-quotas.md` with the provided content and front matter. 
- Changes are content/config only and do not modify application code or build scripts.

### Testing
- No automated tests were run for this change. 
- Changes were committed to the repository (`git commit`) and files are present in the working tree.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b90937f788324973f132304b0f836)